### PR TITLE
Feat: 견적/견적요청 프리뷰 디자인 수정

### DIFF
--- a/src/components/CustomerSearch/ShopItem.jsx
+++ b/src/components/CustomerSearch/ShopItem.jsx
@@ -32,7 +32,7 @@ const ShopItem = ({ shopInfo }) => {
           <div className="flex items-center gap-0.5">
             <FaStar className="h-[12px] fill-yellow-400" />
             <p className="w-18 text-[12px] font-normal">
-              {shopInfo.starScoreAvg} ({shopInfo.reviewCount})
+              {parseFloat(shopInfo.starScoreAvg).toFixed(1)} ({shopInfo.reviewCount})
             </p>
           </div>
         </div>

--- a/src/components/QuoteRequest/Customer/ShopQuoteRequestList.jsx
+++ b/src/components/QuoteRequest/Customer/ShopQuoteRequestList.jsx
@@ -1,4 +1,3 @@
-//ShopQuoteRequestList.jsx
 import React, { useState } from "react";
 import { formatDate } from "@/utils/formatDate";
 import { BsQuestionCircleFill, BsX } from "react-icons/bs";
@@ -95,13 +94,13 @@ const CustomerEstimate = ({ Info }) => {
           </div>
           <div className="mb-1 flex items-center text-sm">
             <img src={Designer} alt="Designer" className="mr-1.5 h-5 w-5" />
-            <p>
+            <p className="line-clamp-1">
               {Info.shopName} - {Info.groomerName} 디자이너
             </p>
           </div>
           <div className="mb-1 flex items-center text-sm">
             <img src={Schedule} alt="Schedule" className="mr-1.5 h-5 w-5" />
-            <p>{formatDate(Info.beautyDate)}</p>
+            <p className="line-clamp-1">{formatDate(Info.beautyDate)}</p>
           </div>
           <div className="flex items-center text-sm">
             <img src={Note} alt="Description" className="mr-1.5 h-5 w-5" />
@@ -131,7 +130,7 @@ const CustomerEstimate = ({ Info }) => {
         )}
         <div
           onClick={() => {
-            /*TODO: 매장 상세로 navigate*/
+            navigate(`/customer/shop/${Info.shopId}`);
           }}
           className="flex h-[35px] w-full cursor-pointer items-center justify-center rounded-lg bg-main text-center text-sm text-white"
         >

--- a/src/components/QuoteRequest/Customer/TotalQuoteRequestList.jsx
+++ b/src/components/QuoteRequest/Customer/TotalQuoteRequestList.jsx
@@ -39,12 +39,12 @@ const CustomerEstimate = ({ Info, expandedQuoteRequestId, setExpandedQuoteReques
     }
   };
 
-  const getQuoteStatusProps = (status) => {
+  const getQuoteStatusProps = (status, expireDate) => {
     switch (status) {
       case "제안":
         return {
           className: "bg-main-100 text-main-500",
-          text: "수락 가능"
+          text: `${formatDate(expireDate)}까지`
         };
       case "수락":
         return {
@@ -84,11 +84,11 @@ const CustomerEstimate = ({ Info, expandedQuoteRequestId, setExpandedQuoteReques
             </div>
             <div className="mb-1 flex items-center text-sm">
               <img src={Region} alt="Description" className="mr-1.5 h-5 w-5" />
-              <p>{Info.region}</p>
+              <p className="line-clamp-1">{Info.region}</p>
             </div>
             <div className="mb-1 flex items-center text-sm">
               <img src={Schedule} alt="Description" className="mr-1.5 h-5 w-5" />
-              <p>{formatDate(Info.beautyDate)}</p>
+              <p className="line-clamp-1">{formatDate(Info.beautyDate)}</p>
             </div>
             <div className="flex items-center text-sm">
               <img src={Note} alt="Description" className="mr-1.5 h-5 w-5" />
@@ -123,7 +123,7 @@ const CustomerEstimate = ({ Info, expandedQuoteRequestId, setExpandedQuoteReques
                   <span
                     className={`rounded-md px-1.5 py-0.5 text-xs ${getQuoteStatusProps(quote.quoteStatus).className}`}
                   >
-                    {getQuoteStatusProps(quote.quoteStatus).text}
+                    {getQuoteStatusProps(quote.quoteStatus, quote.expireDate).text}
                   </span>
                 </div>
               </div>
@@ -162,7 +162,11 @@ const CustomerEstimate = ({ Info, expandedQuoteRequestId, setExpandedQuoteReques
                   </div>
                   <div
                     onClick={() => {
-                      /*TODO: 매장 상세로 navigate*/
+                      if (quote.shopId) {
+                        navigate(`/customer/shop/${quote.shopId}`);
+                      } else {
+                        console.log("유효하지 않은 shopId입니다.");
+                      }
                     }}
                     className={
                       "flex h-[35px] w-full cursor-pointer items-center justify-center rounded-lg bg-main text-center text-sm text-white"

--- a/src/components/QuoteRequest/Groomer/GroomerSentRequests.jsx
+++ b/src/components/QuoteRequest/Groomer/GroomerSentRequests.jsx
@@ -16,28 +16,57 @@ function GroomerSentRequests({ Infos }) {
 const GroomerEstimate = ({ Info }) => {
   const navigate = useNavigate();
 
+  const getStatusProps = (status) => {
+    switch (status) {
+      case "제안":
+        return {
+          className: "bg-main-100 text-main-500",
+          text: "수락 대기중"
+        };
+      case "수락":
+        return {
+          className: "bg-gray-200",
+          text: "예약 완료"
+        };
+      case "마감":
+        return {
+          className: "bg-gray-200",
+          text: "마감"
+        };
+      default:
+        return {
+          className: "",
+          text: status
+        };
+    }
+  };
+
   return (
     <div className="m-5 rounded-xl bg-white p-4">
       <div className="mb-3 flex">
         <img src={Info.userProfileImage} alt="고객 프로필" className="mr-3 h-10 w-10 rounded-lg object-cover" />
         <div className="w-full">
           <div className="flex gap-1">
-            <p className="px-0.5 font-semibold leading-[1.1]">{Info.userName} 고객님</p>
+            <p className="line-clamp-1 px-0.5 font-semibold leading-[1.1]">{Info.userName} 고객님</p>
             {Info.requestType == "020" ? (
               <span className="flex items-center rounded-md bg-main px-1.5 text-xs text-white">1:1 맞춤 요청</span>
             ) : null}
           </div>
-          <span className="rounded-md bg-main-100 px-1 py-[1px] text-xs text-main-500">{Info.status}</span>
+          <span
+            className={`rounded-md bg-main-100 px-1 py-[1px] text-xs text-main-500 ${getStatusProps(Info.status).className}`}
+          >
+            {getStatusProps(Info.status).text}
+          </span>
         </div>
       </div>
       <div className="mb-2 text-sm">
         <div className="mb-1 flex items-center">
           <img src={Schedule} alt="Description" className="mr-2 h-5 w-5" />
-          <p>{formatDate(Info.beautyDate)}</p>
+          <p className="line-clamp-1">{formatDate(Info.beautyDate)}</p>
         </div>
         <div className="mb-1 flex items-center">
           <img src={Corgi} alt="Description" className="mr-2 h-5 w-5" />
-          <p>
+          <p className="line-clamp-1">
             {Info.dogBreed} • {Info.dogGender == "MALE" ? "남아" : "여아"} • {Info.dogWeight}kg
           </p>
         </div>

--- a/src/components/QuoteRequest/Groomer/GroomerShopRequests.jsx
+++ b/src/components/QuoteRequest/Groomer/GroomerShopRequests.jsx
@@ -57,7 +57,7 @@ const GroomerEstimate = ({ Info }) => {
       <div className="mb-3 flex">
         <img src={Info.userProfileImage} alt="고객 프로필" className="mr-3 h-10 w-10 rounded-lg object-cover" />
         <div>
-          <p className="px-0.5 font-semibold leading-[1.1]">{Info.userName} 고객님</p>
+          <p className="line-clamp-1 px-0.5 font-semibold leading-[1.1]">{Info.userName} 고객님</p>
           <span className="rounded-md bg-main-100 px-1 py-[1px] text-xs text-main">
             {formatDate(Info.expiryDate)}까지
           </span>
@@ -66,11 +66,11 @@ const GroomerEstimate = ({ Info }) => {
       <div className="mb-2 text-sm">
         <div className="mb-1 flex items-center">
           <img src={Schedule} alt="Description" className="mr-2 h-5 w-5" />
-          <p>{formatDate(Info.beautyDate)}</p>
+          <p className="line-clamp-1">{formatDate(Info.beautyDate)}</p>
         </div>
         <div className="mb-1 flex items-center">
           <img src={Corgi} alt="Description" className="mr-2 h-5 w-5" />
-          <p>
+          <p className="line-clamp-1">
             {Info.dogBreed} • {Info.dogGender == "MALE" ? "남아" : "여아"} • {Info.dogWeight}kg
           </p>
         </div>

--- a/src/components/QuoteRequest/Groomer/GroomerTotalRequests.jsx
+++ b/src/components/QuoteRequest/Groomer/GroomerTotalRequests.jsx
@@ -30,11 +30,11 @@ const GroomerEstimate = ({ Info }) => {
       <div className="mb-2 text-sm">
         <div className="mb-1 flex items-center">
           <img src={Schedule} alt="Description" className="mr-2 h-5 w-5" />
-          <p>{formatDate(Info.beautyDate)}</p>
+          <p className="line-clamp-1">{formatDate(Info.beautyDate)}</p>
         </div>
         <div className="mb-1 flex items-center">
           <img src={Corgi} alt="Description" className="mr-2 h-5 w-5" />
-          <p>
+          <p className="line-clamp-1">
             {Info.dogBreed} • {Info.dogGender == "MALE" ? "남아" : "여아"} • {Info.dogWeight}kg
           </p>
         </div>


### PR DESCRIPTION
매장 상세로 navigate 추가
무조건 한 줄까지만 표시되도록 수정
ShopItem 매장 평균 별점 소수점 첫째자리로 반올림

Related to #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 평균 별점 표시 형식 개선: 소수점 한 자리로 표시됩니다.
	- "매장 상세보기" 버튼의 내비게이션 로직 개선: 직접적인 매장 상세 페이지로의 이동 구현.
	- 제안 상태에 만료 날짜 표시 추가 및 내비게이션 오류 처리 개선.

- **UI 개선**
	- 여러 텍스트 요소에 `line-clamp-1` 클래스 추가: 텍스트 오버플로우 방지 및 시각적 레이아웃 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->